### PR TITLE
Fix navigation setup

### DIFF
--- a/MobileApp/App.tsx
+++ b/MobileApp/App.tsx
@@ -5,6 +5,7 @@ import { createDrawerNavigator } from '@react-navigation/drawer';
 
 // 1. IMPORTA el contenedor de gestos
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 // Importamos las pantallas
 import { HomeScreen } from './src/screens/HomeScreen';
@@ -19,23 +20,24 @@ const App = () => {
   return (
     // 2. ENVUELVE todo con GestureHandlerRootView
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <NavigationContainer>
-        <Drawer.Navigator
-          initialRouteName="Inicio"
-          screenOptions={{
-            headerStyle: { backgroundColor: '#2c3e50' },
-            headerTintColor: '#fff',
-            drawerActiveBackgroundColor: '#3498db',
-            drawerActiveTintColor: '#fff',
-          }}
-        >
+      <SafeAreaProvider>
+        <NavigationContainer>
+          <Drawer.Navigator
+            initialRouteName="Inicio"
+            screenOptions={{
+              headerStyle: { backgroundColor: '#2c3e50' },
+              headerTintColor: '#fff',
+              drawerActiveBackgroundColor: '#3498db',
+              drawerActiveTintColor: '#fff',
+            }}>
           <Drawer.Screen name="Inicio" component={HomeScreen} />
           <Drawer.Screen name="Ejercicios" component={ExercisesScreen} />
           <Drawer.Screen name="Planes" component={PlansScreen} />
           <Drawer.Screen name="Perfil" component={ProfileScreen} />
           <Drawer.Screen name="Contacto" component={ContactScreen} />
         </Drawer.Navigator>
-      </NavigationContainer>
+        </NavigationContainer>
+      </SafeAreaProvider>
     </GestureHandlerRootView>
   );
 };

--- a/MobileApp/package.json
+++ b/MobileApp/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "@react-native/new-app-screen": "0.80.0",
     "@react-navigation/drawer": "^7.5.2",
+    "@react-navigation/native": "^6.2.2",
+    "react-native-safe-area-context": "^4.8.2",
+    "react-native-screens": "^3.29.0",
     "react": "19.1.0",
     "react-native": "0.80.0",
     "react-native-gesture-handler": "^2.26.0"


### PR DESCRIPTION
## Summary
- add missing navigation packages
- wrap navigator in SafeAreaProvider so native module loads

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686293a34a5c8320b1082f5b1202f71b