### PR TITLE
Fix React Native drawer runtime error

### DIFF
--- a/MobileApp/babel.config.js
+++ b/MobileApp/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
+  plugins: ['react-native-reanimated/plugin'],
 };

--- a/MobileApp/index.js
+++ b/MobileApp/index.js
@@ -3,6 +3,7 @@
  */
 
 import { AppRegistry } from 'react-native';
+import 'react-native-reanimated';
 import App from './App';
 import { name as appName } from './app.json';
 

--- a/MobileApp/package-lock.json
+++ b/MobileApp/package-lock.json
@@ -12,7 +12,8 @@
         "@react-navigation/drawer": "^7.5.2",
         "react": "19.1.0",
         "react-native": "0.80.0",
-        "react-native-gesture-handler": "^2.26.0"
+        "react-native-gesture-handler": "^2.26.0",
+        "react-native-reanimated": "^3.18.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/MobileApp/package.json
+++ b/MobileApp/package.json
@@ -17,7 +17,8 @@
     "react-native-screens": "^3.29.0",
     "react": "19.1.0",
     "react-native": "0.80.0",
-    "react-native-gesture-handler": "^2.26.0"
+    "react-native-gesture-handler": "^2.26.0",
+    "react-native-reanimated": "^3.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add `react-native-reanimated` as a project dependency
- configure Babel to load the reanimated plugin
- import `react-native-reanimated` in the entry file

These changes ensure the `@react-navigation/drawer` package works without throwing `Cannot read property 'makeMutable' of undefined` at runtime.

## Testing
- `npm test` *(fails: jest not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68629870c7fc8320b34c1ff5fd15018d