### PR TITLE
Fix android build kotlin version

### DIFF
--- a/MobileApp/android/build.gradle
+++ b/MobileApp/android/build.gradle
@@ -5,7 +5,10 @@ buildscript {
         compileSdkVersion = 35
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.1.20"
+        // React Native 0.72.x expects Kotlin 1.9.x. Using Kotlin 2.x causes
+        // build errors like unresolved reference `serviceOf` in the Gradle
+        // plugin scripts. Stick to a compatible Kotlin version.
+        kotlinVersion = "1.9.22"
     }
     repositories {
         google()


### PR DESCRIPTION
## Summary
- fix unresolved `serviceOf` error by using Kotlin 1.9.22

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862b5943ca08320b5d4ed3f72267d9f