### PR TITLE
Fix Kotlin plugin version handling

### DIFF
--- a/MobileApp/android/build.gradle
+++ b/MobileApp/android/build.gradle
@@ -7,8 +7,10 @@ buildscript {
         ndkVersion = "27.1.12297006"
         // React Native 0.72.x expects Kotlin 1.9.x. Using Kotlin 2.x causes
         // build errors like unresolved reference `serviceOf` in the Gradle
-        // plugin scripts. Stick to a compatible Kotlin version.
-        kotlinVersion = "1.9.22"
+        // plugin scripts. Stick to a compatible Kotlin version. Use the value
+        // defined in gradle.properties so that included builds (like the React
+        // Native gradle plugin) pick up the same version.
+        kotlinVersion = project.properties["kotlinVersion"]
     }
     repositories {
         google()

--- a/MobileApp/android/gradle.properties
+++ b/MobileApp/android/gradle.properties
@@ -37,3 +37,8 @@ newArchEnabled=false
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
+
+# Keep the Kotlin version in sync across all Gradle builds. React Native 0.72.x
+# expects Kotlin 1.9.x. Newer Kotlin releases break the gradle-plugin
+# compilation with errors like `unresolved reference: serviceOf`.
+kotlinVersion=1.9.22

--- a/MobileApp/android/settings.gradle
+++ b/MobileApp/android/settings.gradle
@@ -1,4 +1,18 @@
-pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
+pluginManagement {
+    includeBuild("../node_modules/@react-native/gradle-plugin")
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id.startsWith("org.jetbrains.kotlin")) {
+                useVersion(settings.extra["kotlinVersion"] as String)
+            }
+        }
+    }
+}
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'MobileApp'


### PR DESCRIPTION
## Summary
- share kotlinVersion across gradle builds via gradle.properties
- pin Kotlin plugin version during plugin resolution

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862b93e6a108320b1368a53ae696325